### PR TITLE
Update python_version for 3.13

### DIFF
--- a/dshield.json
+++ b/dshield.json
@@ -14,7 +14,7 @@
     "min_phantom_version": "5.1.0",
     "fips_compliant": true,
     "app_wizard_version": "1.0.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "logo": "logo_dshield.svg",
     "logo_dark": "logo_dshield_dark.svg",
     "license": "Copyright (c) 2017-2025 Splunk Inc.",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)